### PR TITLE
use github cache to speedup bazel loading phase

### DIFF
--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -4,7 +4,10 @@ description: |
   * set home bazelrc
 
 inputs:
-  buildbuddy_api_key:
+  bazel-cache-key:
+    required: false
+    default : bazel-external-cache
+  buildbuddy-api-key:
     required: false
 
 runs:
@@ -23,5 +26,21 @@ runs:
       shell: bash
       run: |
         cp .github/workflows/ci.bazelrc ~/.bazelrc
-        echo 'build --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy_api_key }}' >> ~/.bazelrc
+        echo 'build --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy-api-key }}' >> ~/.bazelrc
+
+    - name: setup bazel install base, output base, repository cache
+      shell: bash
+      run: |
+        echo "startup --install_base=$HOME/bazel_cache/install_base" >> ~/.bazelrc
+        echo "startup --output_base=$HOME/bazel_cache/output_base" >> ~/.bazelrc
+        echo "common --repository_cache=$HOME/bazel_cache/repository_cache" >> ~/.bazelrc
+
+    - name: mount bazel install base, output base, repository cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/bazel_cache/install_base
+          ~/bazel_cache/output_base/external
+          ~/bazel_cache/repository_cache
+        key: ${{ inputs.bazel-cache-key }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,29 +14,44 @@ jobs:
       matrix:
         toolchain: [gcc, clang]
         feature: ['', asan, tsan, ubsan]
-
+    env:
+      PROFILE: profile-${{ matrix.toolchain }}-${{ matrix.feature }}.gz
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/ci-env-setup
       with:
-        buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
         bazel \
           test \
+          --profile=$PROFILE \
           --config=${{ matrix.toolchain }} \
           --features=${{ matrix.feature }} \
           //...
 
+        bazel analyze-profile $PROFILE
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.PROFILE }}
+        path : ${{ env.PROFILE }}
+
   coverage:
     runs-on: ubuntu-latest
+    env:
+      PROFILE: profile-coverage.gz
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/ci-env-setup
       with:
-        buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
-        bazel run //tools:lcov_list
+        bazel run --profile=$PROFILE //tools:lcov_list
 
+        bazel analyze-profile $PROFILE
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.PROFILE }}
+        path : ${{ env.PROFILE }}
     - uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -55,14 +70,21 @@ jobs:
           - '--compilation_mode=opt'
         exclude:
           - flag: ${{ github.event_name == 'pull_request' && '--config=verbose-clang-tidy' || 'dummy' }}
-
+    env:
+      PROFILE: profile-${{ matrix.flag }}.gz
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/ci-env-setup
       with:
-        buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
-        bazel build ${{ matrix.flag }} //...
+        bazel build --profile=$PROFILE ${{ matrix.flag }} //...
+
+        bazel analyze-profile $PROFILE
+    - uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.PROFILE }}
+        path : ${{ env.PROFILE }}
 
   buildifier:
     runs-on: ubuntu-latest
@@ -70,6 +92,6 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/ci-env-setup
       with:
-        buildbuddy_api_key: ${{ secrets.BUILDBUDDY_API_KEY }}
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
         bazel run //tools:buildifier.check


### PR DESCRIPTION
Cache Bazel's install_base, output_base/external, and repository_cache
directories to reduce the duration of the loading phase[0].

Without use of cache for these directories, extracting the LLVM
toolchain takes roughly 2 minutes for Github runners. The LLVM toolchain
is always required as the repository is referenced via `.bazelrc` and
`//toolchain:BUILD.bazel`.

[0]: https://bazel.build/extending/repo#implementation_function

Change-Id: If05cdf7faf25ed6885ba1f357e58e987bdf4858b